### PR TITLE
エラー処理の変更

### DIFF
--- a/src/Exception/ApiErrorException.php
+++ b/src/Exception/ApiErrorException.php
@@ -1,0 +1,48 @@
+<?php
+namespace Polidog\Esa\Exception;
+
+use GuzzleHttp\Exception\ClientException;
+
+class ApiErrorException extends \RuntimeException
+{
+    /**
+     * @var string
+     */
+    private $apiMethodName;
+
+    /**
+     * @var array
+     */
+    private $args;
+
+    /**
+     * @return string
+     */
+    public function getApiMethodName()
+    {
+        return $this->apiMethodName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgs()
+    {
+        return $this->args;
+    }
+
+    /**
+     * @param \Exception $e
+     * @param            $name
+     * @param array      $args
+     * @return ApiErrorException
+     */
+    public static function newException(\Exception $e, $name, array $args)
+    {
+        $self = new self(sprintf("Api method error: %s", $name), $e->getCode(), $e);
+        $self->apiMethodName = $name;
+        $self->args = $args;
+        return $self;
+    }
+
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,16 +19,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         Phake::when($httpClient)->request('GET', 'teams')
             ->thenReturn($response);
 
-        Phake::when($response)->getStatusCode()
-            ->thenReturn(200);
-
         Phake::when($response)->getBody()
             ->thenReturn($stream);
 
         $client = new Client('token', 'polidog', $httpClient);
         $client->teams();
 
-        Phake::verify($response)->getStatusCode();
         Phake::verify($response)->getBody();
         Phake::verify($stream)->getContents();
     }


### PR DESCRIPTION
Api実行時に、HTTP Status Codeが200の場合のみ情報をreturnしていたので、すべてのステータスにおいて情報をリターンするように変更。

400,500エラー時はApiErrorExceptionがthrowするように変更。

